### PR TITLE
Add filter to view all reviews

### DIFF
--- a/WordPress_Moderator_Tools_Chrome.user.js
+++ b/WordPress_Moderator_Tools_Chrome.user.js
@@ -414,8 +414,6 @@ moderator_tools_with_jquery( function( $ ) {
 			author: '.reviewer-name'
 		};
 
-		$( "head" ).append( '<style type=\"text/css\">' + styles + '</style>' );
-
 		// test if duplicate IPs are found
 
 		// var ip1 = next_prev_objects.eq( 0 ).find( '.post-ip-link' ).text();
@@ -424,8 +422,9 @@ moderator_tools_with_jquery( function( $ ) {
 		// }
 
 		check_duplicate_IPs();
-		
 		viewAllReviews();
+
+		$( "head" ).append( '<style type=\"text/css\">' + styles + '</style>' );
 	}
 
 
@@ -1394,7 +1393,7 @@ moderator_tools_with_jquery( function( $ ) {
 
 		// Only apply if on the first reviews page
 		if (pagination.children().first().hasClass('current')) {
-			var button = $('<button class="reviews-toggle-all">Show all reviews</button>');
+			var button = $('<button class="button reviews-toggle-all">Show all reviews</button>');
 
 			// Create a button for this filter
 			wrapper.prepend(button);
@@ -1451,6 +1450,25 @@ moderator_tools_with_jquery( function( $ ) {
 				}
 
 			});
+			
+			// Add some CSS
+			styles += 
+				'.reviews-toggle-all { ' +
+					'margin-bottom: 2em;' +
+					 'padding-right: 2em;' +
+					 'position: relative;' +
+				'}' +
+				'.reviews-toggle-all:after {' +
+					 'content: "+";' +
+					 'position: absolute;' +
+					 'right: 10px;' +
+					 'top: 0;' +
+					 'font-family: serif' + 
+					 'font-size: 16px;' +
+				'}' +		
+				'.reviews-toggle-all--visible:after {' +
+					 'content: "-";' +
+				'}';
 		}
 	}
 

--- a/WordPress_Moderator_Tools_Chrome.user.js
+++ b/WordPress_Moderator_Tools_Chrome.user.js
@@ -1394,39 +1394,35 @@ moderator_tools_with_jquery( function( $ ) {
 
 		// Only apply if on the first reviews page
 		if (pagination.children().first().hasClass('current')) {
-			var totalReviews = $('.reviews-total-count span[itemprop="reviewCount"]'),
-				totalReviewsCount = totalReviews.text(),
-				button = $('<button>Show ' + totalReviews.text() + ' reviews</button>'),
-				currentReviews = $('.review').length;
+			var button = $('<button class="reviews-toggle-all">Show all reviews</button>');
 
 			// Create a button for this filter
-			totalReviews.before(button);
-			totalReviews.remove();
+			wrapper.prepend(button);
 
 			button.click(function()  {
 				// If all reviews are shown
-				if (button.hasClass('reviews-total-count--visible')) {
+				if (button.hasClass('reviews-toggle-all--visible')) {
 					// Hide the reviews
 					container.hide();
 					button
-						.text('Show ' + totalReviews.text() + ' reviews')
-						.removeClass('reviews-total-count--visible');
+						.text('Show all reviews')
+						.removeClass('reviews-toggle-all--visible');
 				} 
 				// If all reviews are hidden but the button has been pressed
-				else if (button.hasClass('reviews-total-count--toggled')) {
+				else if (button.hasClass('reviews-toggle-all--toggled')) {
 					// Show the reviews
 					container.show();
 					button
-						.text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
-						.addClass('reviews-total-count--visible');
+						.text('Show less reviews')
+						.addClass('reviews-toggle-all--visible');
 				} else {
                     var i = 1;
 
 					// Toggle the text
 					button
-						.text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
+						.text('Show less reviews')
 						// also add a toggled classes to target
-						.addClass('reviews-total-count--toggled reviews-total-count--visible');
+						.addClass('reviews-toggle-all--toggled reviews-toggle-all--visible');
 
 					// Looping each review page
 					for (pageCount; pageCount < lastPage.text(); pageCount++)  {

--- a/WordPress_Moderator_Tools_Chrome.user.js
+++ b/WordPress_Moderator_Tools_Chrome.user.js
@@ -1442,6 +1442,9 @@ moderator_tools_with_jquery( function( $ ) {
                                 // Fill the Duplicate IP variable with the updated reviews
                                 next_prev_objects = $('.reviewer');
 
+								// Remove current duplicate IP warnings
+								$('.wpmt_ip-warning').remove();
+
                                 // Run the Duplicate IP script again
                                 check_duplicate_IPs();   
                             }

--- a/WordPress_Moderator_Tools_Chrome.user.js
+++ b/WordPress_Moderator_Tools_Chrome.user.js
@@ -1104,7 +1104,7 @@ moderator_tools_with_jquery( function( $ ) {
 				}
 			}
 		} );
-
+        
 		// if no duplicates return
 		if ( $.isEmptyObject( duplicate_IPs ) ) {
 			return;
@@ -1421,27 +1421,37 @@ moderator_tools_with_jquery( function( $ ) {
 					.text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
 					.addClass('reviews-total-count--visible');
 				} else {
+                    var i = 1;
+
 					// Toggle the text
 					button
-					.text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
-					// also add a toggled classes to target
-					.addClass('reviews-total-count--toggled reviews-total-count--visible');
+                    .text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
+                    // also add a toggled classes to target
+                    .addClass('reviews-total-count--toggled reviews-total-count--visible');
 
 					// Looping each review page
 					for (pageCount; pageCount < lastPage.text(); pageCount++)  {
 
 						// Grab the contents of each review page
-						$.get(url + '/page/' + pageCount, function(data) {
+						$.get(url + '/page/' + (pageCount + 1), function(data) {
 							var reviews = $(data).find('.review');
 
 							// Append the reviews to the current first page
 							container.append(reviews);
-						});
-					}
-					
-					// Run the duplicate IPs check again
-					check_duplicate_IPs();
+                        
+                            // If the final set of reviews have been grabbed
+                            if (i === parseInt(lastPage.text()) - 1) {
+                    
+                                // Fill the Duplicate IP variable with the updated reviews
+                                next_prev_objects = $('.reviewer');
 
+                                // Run the Duplicate IP script again
+                                check_duplicate_IPs();   
+                            }
+
+                            i++;
+						});
+					}  
 				}
 
 			});

--- a/WordPress_Moderator_Tools_Chrome.user.js
+++ b/WordPress_Moderator_Tools_Chrome.user.js
@@ -424,6 +424,8 @@ moderator_tools_with_jquery( function( $ ) {
 		// }
 
 		check_duplicate_IPs();
+		
+		viewAllReviews();
 	}
 
 
@@ -1378,6 +1380,74 @@ moderator_tools_with_jquery( function( $ ) {
 		return 0;
 	}
 
+	/**
+	 * Filter to view all reviews on the first review page 
+	 */ 
+	function viewAllReviews() {
+		var pagination = $('#pages').first(),
+			pages = $(pagination).find('a').not('.next'),
+			lastPage = pages.last(),
+			pageCount = 1,
+			url = window.location.href,
+			container = $('<div class="all-reviews_container" />'),
+			wrapper = $('.all-reviews').append(container);
+
+		// Only apply if on the first reviews page
+		if (pagination.children().first().hasClass('current')) {
+			var totalReviews = $('.reviews-total-count span[itemprop="reviewCount"]'),
+				totalReviewsCount = totalReviews.text(),
+				button = $('<button class="reviews-total-count">Show ' + totalReviews.text() + ' reviews</button>'),
+				currentReviews = $('.review').length;
+
+			// Create a button for this filter
+			totalReviews.before(button);
+			totalReviews.remove();
+
+			button.click(function() {
+
+				// If all reviews are shown
+				if (button.hasClass('reviews-total-count--visible')) {
+					// Hide the reviews
+					container.hide();
+					button
+					.text('Show ' + totalReviews.text() + ' reviews')
+					.removeClass('reviews-total-count--visible');
+				} 
+				// If all reviews are hidden but the button has been pressed
+				else if (button.hasClass('reviews-total-count--toggled')) {
+					// Show the reviews
+					container.show();
+					button
+					.text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
+					.addClass('reviews-total-count--visible');
+				} else {
+					// Toggle the text
+					button
+					.text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
+					// also add a toggled classes to target
+					.addClass('reviews-total-count--toggled reviews-total-count--visible');
+
+					// Looping each review page
+					for (pageCount; pageCount < lastPage.text(); pageCount++)  {
+
+						// Grab the contents of each review page
+						$.get(url + '/page/' + pageCount, function(data) {
+							var reviews = $(data).find('.review');
+
+							// Append the reviews to the current first page
+							container.append(reviews);
+						});
+					}
+					
+					// Run the duplicate IPs check again
+					check_duplicate_IPs();
+
+				}
+
+			});
+
+		}
+	}
 
 	init();
 

--- a/WordPress_Moderator_Tools_Chrome.user.js
+++ b/WordPress_Moderator_Tools_Chrome.user.js
@@ -1396,7 +1396,7 @@ moderator_tools_with_jquery( function( $ ) {
 		if (pagination.children().first().hasClass('current')) {
 			var totalReviews = $('.reviews-total-count span[itemprop="reviewCount"]'),
 				totalReviewsCount = totalReviews.text(),
-				button = $('<button class="reviews-total-count">Show ' + totalReviews.text() + ' reviews</button>'),
+				button = $('<button>Show ' + totalReviews.text() + ' reviews</button>'),
 				currentReviews = $('.review').length;
 
 			// Create a button for this filter

--- a/WordPress_Moderator_Tools_Chrome.user.js
+++ b/WordPress_Moderator_Tools_Chrome.user.js
@@ -1403,35 +1403,33 @@ moderator_tools_with_jquery( function( $ ) {
 			totalReviews.before(button);
 			totalReviews.remove();
 
-			button.click(function() {
-
+			button.click(function()  {
 				// If all reviews are shown
 				if (button.hasClass('reviews-total-count--visible')) {
 					// Hide the reviews
 					container.hide();
 					button
-					.text('Show ' + totalReviews.text() + ' reviews')
-					.removeClass('reviews-total-count--visible');
+						.text('Show ' + totalReviews.text() + ' reviews')
+						.removeClass('reviews-total-count--visible');
 				} 
 				// If all reviews are hidden but the button has been pressed
 				else if (button.hasClass('reviews-total-count--toggled')) {
 					// Show the reviews
 					container.show();
 					button
-					.text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
-					.addClass('reviews-total-count--visible');
+						.text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
+						.addClass('reviews-total-count--visible');
 				} else {
                     var i = 1;
 
 					// Toggle the text
 					button
-                    .text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
-                    // also add a toggled classes to target
-                    .addClass('reviews-total-count--toggled reviews-total-count--visible');
+						.text('Hide ' + (parseInt(totalReviewsCount) - currentReviews) + ' reviews')
+						// also add a toggled classes to target
+						.addClass('reviews-total-count--toggled reviews-total-count--visible');
 
 					// Looping each review page
 					for (pageCount; pageCount < lastPage.text(); pageCount++)  {
-
 						// Grab the contents of each review page
 						$.get(url + '/page/' + (pageCount + 1), function(data) {
 							var reviews = $(data).find('.review');
@@ -1441,7 +1439,6 @@ moderator_tools_with_jquery( function( $ ) {
                         
                             // If the final set of reviews have been grabbed
                             if (i === parseInt(lastPage.text()) - 1) {
-                    
                                 // Fill the Duplicate IP variable with the updated reviews
                                 next_prev_objects = $('.reviewer');
 
@@ -1455,10 +1452,8 @@ moderator_tools_with_jquery( function( $ ) {
 				}
 
 			});
-
 		}
 	}
 
 	init();
-
 } );

--- a/WordPress_Moderator_Tools_Chrome.user.js
+++ b/WordPress_Moderator_Tools_Chrome.user.js
@@ -1388,12 +1388,12 @@ moderator_tools_with_jquery( function( $ ) {
 			lastPage = pages.last(),
 			pageCount = 1,
 			url = window.location.href,
-			container = $('<div class="all-reviews_container" />'),
+			container = $('<div class="all-reviews_container" id="all-reviews_container"/>'),
 			wrapper = $('.all-reviews').append(container);
 
 		// Only apply if on the first reviews page
 		if (pagination.children().first().hasClass('current')) {
-			var button = $('<button class="button reviews-toggle-all">Show all reviews</button>');
+			var button = $('<button aria-controls="all-reviews_container"  aria-expanded="false" class="button reviews-toggle-all">All reviews</button>');
 
 			// Create a button for this filter
 			wrapper.prepend(button);
@@ -1404,24 +1404,27 @@ moderator_tools_with_jquery( function( $ ) {
 					// Hide the reviews
 					container.hide();
 					button
-						.text('Show all reviews')
-						.removeClass('reviews-toggle-all--visible');
+						.text('All reviews')
+						.removeClass('reviews-toggle-all--visible')
+						.attr('aria-expanded', false);
 				} 
 				// If all reviews are hidden but the button has been pressed
 				else if (button.hasClass('reviews-toggle-all--toggled')) {
 					// Show the reviews
 					container.show();
 					button
-						.text('Show less reviews')
-						.addClass('reviews-toggle-all--visible');
+						.text('Fewer reviews')
+						.addClass('reviews-toggle-all--visible')
+						.attr('aria-expanded', true);
 				} else {
                     var i = 1;
 
-					// Toggle the text
+					// Update the button attributes accordingly
 					button
-						.text('Show less reviews')
+						.text('Fewer reviews')
 						// also add a toggled classes to target
-						.addClass('reviews-toggle-all--toggled reviews-toggle-all--visible');
+						.addClass('reviews-toggle-all--toggled reviews-toggle-all--visible')
+						.attr('aria-expanded', true);
 
 					// Looping each review page
 					for (pageCount; pageCount < lastPage.text(); pageCount++)  {


### PR DESCRIPTION
An option will appear on the first Reviews page of a plugin or theme that will toggle all reviews on the same page. This is to help find duplicate IPs easier.