### PR TITLE
Add button to strip links in editor

### DIFF
--- a/WordPress_Moderator_Tools_Chrome.user.js
+++ b/WordPress_Moderator_Tools_Chrome.user.js
@@ -1646,7 +1646,7 @@ moderator_tools_with_jquery( function( $ ) {
 				 .replace( matches.www, replaceContent );
 	 
 			// Update the post content 
-			post.html( updatedContent );
+			post.val( updatedContent );
 		}
 	 
 		addBtn();


### PR DESCRIPTION
Though - I want to do this for only the editor when you edit a Review, because the button is kind of redundant otherwise. I just can't figure out a way to do that.

Test: https://wordpress.org/support/edit.php?id=6772875